### PR TITLE
Only transition/reward with valid movement actions (not gaze)

### DIFF
--- a/gym_game/envs/dm2s_env.py
+++ b/gym_game/envs/dm2s_env.py
@@ -163,7 +163,7 @@ class Dm2sEnv(FiniteStateEnv):
     # Only transition if action in scope of dm2s actions
     if action < self.NUM_ACTIONS:
       if old_state_key == self.STATE_PLAY_SHOW:
-        if action != self.ACTION_NONE:
+        if action in [self.ACTION_LEFT, self.ACTION_RIGHT]:
           if self.result is None:
             if action == self.position:
               self.result = self.RESULT_CORRECT
@@ -199,11 +199,11 @@ class Dm2sEnv(FiniteStateEnv):
     return old_state_key
 
   def _update_reward(self, old_state_key, action, elapsed_time, new_state_key):
-    """Reward is always zero unless in the PLAY_SHOW state and the action is not zero. 
+    """Reward is always zero unless in the PLAY_SHOW state and the action is not zero.
     In that case it is 1 if correct and -1 otherwise."""
     reward = 0.0
     if old_state_key == self.STATE_PLAY_SHOW:
-      if action != self.ACTION_NONE:
+      if action in [self.ACTION_LEFT, self.ACTION_RIGHT]:
         if action == self.position:
           reward = 1.0
         else:

--- a/gym_game/envs/m2s_env.py
+++ b/gym_game/envs/m2s_env.py
@@ -59,7 +59,7 @@ class M2sEnv(Dm2sEnv):
     new_state_key = old_state_key  # default
     next_state_keys = self.get_next_state_keys(old_state_key)
     if old_state_key == self.STATE_PLAY_SHOW:
-      if action != self.ACTION_NONE:
+      if action in [self.ACTION_LEFT, self.ACTION_RIGHT]:
         if self.result is None:
           if action == self.position:
             self.result = self.RESULT_CORRECT


### PR DESCRIPTION
In M2S and DM2S environments, we were checking if an action is not `ACTION_NONE` (i.e. `0`), before proceeding with state transition or reward. With this condition in place, 'gaze actions' will be able to transition the environment because they not equal to `ACTION_NONE`.

Instead, I have modified this logic to instead ensure that the `action` specified is within the range of actions `[self.ACTION_LEFT, self.ACTION_RIGHT]` before proceeding.