### PR TITLE
Fix upper-bound issue in channel dim range using retina_output

### DIFF
--- a/agent/stubs/visual_path.py
+++ b/agent/stubs/visual_path.py
@@ -103,8 +103,8 @@ class VisualPath(nn.Module):
       writer.add_histogram(self._name + '/retina-input', x, global_step=self.STEP)
       writer.add_histogram(self._name + '/retina-output', retina_output, global_step=self.STEP)
 
-      dog_pos = retina_output[:, 0:2, :, :]
-      dog_neg = retina_output[:, 3:5, :, :]
+      dog_pos = retina_output[:, 0:3, :, :]
+      dog_neg = retina_output[:, 3:6, :, :]
       writer.add_image(self._name + '/retina-output-dog+', torchvision.utils.make_grid(dog_pos), global_step=self.STEP)
       writer.add_image(self._name + '/retina-output-dog-', torchvision.utils.make_grid(dog_neg), global_step=self.STEP)
 

--- a/pretrain_visual_cortex.py
+++ b/pretrain_visual_cortex.py
@@ -62,8 +62,8 @@ def train(args, model, device, train_loader, global_step, optimizer, epoch, writ
       writer.add_image('pre-train/encoding', torchvision.utils.make_grid(encoding_img), global_step)
 
       # when input has 6 channels...
-      dog_pos = output[:, 0:2, :, :]
-      dog_neg = output[:, 3:5, :, :]
+      dog_pos = output[:, 0:3, :, :]
+      dog_neg = output[:, 3:6, :, :]
       writer.add_image('pre-train/dog+recon', torchvision.utils.make_grid(dog_pos), global_step)
       writer.add_image('pre-train/dog-recon', torchvision.utils.make_grid(dog_neg), global_step)
 


### PR DESCRIPTION
Slicing tensors (or arrays) in Python uses half-open interval, so upper-bound is exclusive. This caused a (mostly) visual issue in TensorBoard when visualising the de-concatenated interest filter (retina) output.

Updated the slice range by incrementing the upper bound by `1` to ensure that we are getting all three channel dimensions.

```
retina/dog_neg shape:  torch.Size([1, 3, 74, 74])
retina/dog_pos shape:  torch.Size([1, 3, 74, 74])

retina/interest shape:  torch.Size([1, 6, 74, 74])  # concatenated [dog_pos, dog_neg] on channel dim

retina/decon_dog_pos shape:  torch.Size([1, 3, 74, 74])   # previously was torch.Size([1, 2, 74, 74])
retina/decon_dog_neg shape:  torch.Size([1, 3, 74, 74])   # previously was torch.Size([1, 2, 74, 74])
```